### PR TITLE
Added partials support for property fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ gen-partials
 /example/basic/build/
 /example/metadata/build/
 .mcover
+/example/properties/build/

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Equivalent compiled class:
 
 
 
-## Metadata
+## Method Metadata
 
 By default additional methods and properties are appended the end of the existing code block.
 
@@ -237,6 +237,38 @@ Using this metadata tag on a predefined method in an implementation class will c
 
 	WARNING: example.Test_Foo:14 Cannot define @PartialInline in a partial implementation of example.Test
 	WARNING: example.Test_Foo:14 Converting method foo to standard haxe inline accesor.
+
+
+## Property Metadata
+
+Property fields support a subset of partial metadata options:
+
+
+### Replace
+
+Overrides the base class property definition.
+
+	@PartialReplace
+	public var property:String = "foo";
+
+Unlike methods, there are some restrictions on overriding a property to avoid breaking compatibility with other classes using the public API. This prevents properties being changed from public to private, static to instance, etc
+
+- Compiler error if base propery is marked as final
+- Compiler error if property has no partial metadata (invalid override)
+- Compiler error if property overriden multiple times in the one partial file
+- Compiler error if property types do not match
+- Compiler error if converting getter/setter to a simple var
+- Compiler error if adding/removing static accessor
+- Compiler error if changing/removing existing public access
+- Compiler warning if adding/removing inline accessor
+- Compiler warning if adding public accessor
+
+### Final
+
+Prevents partial classes from modifiying base instance.
+
+	@PartialFinal
+	public var property:String = "bar";
 
 
 ## How it Works

--- a/example/basic/src/example/Display.hx
+++ b/example/basic/src/example/Display.hx
@@ -24,6 +24,8 @@ package example;
 
 class Display implements mpartial.Partial
 {
+	public var debug:Bool = false;
+
 	public var x(default, set_x):Float;
 
 	public var y(default, set_y):Float;

--- a/example/basic/src/example/Display_debug.hx
+++ b/example/basic/src/example/Display_debug.hx
@@ -25,6 +25,8 @@ package example;
 
 class Display_debug
 {
+	@PartialReplace
+	public var debug:Bool = true;
 
 	@PartialAppend
 	public function new()

--- a/example/properties/README.md
+++ b/example/properties/README.md
@@ -1,0 +1,16 @@
+Partials - Properties Example
+=================
+
+This example is intended to demonstrate how Partials can be used override class
+properties using partials.
+
+In this case the Config_debug overrides the values defined in the base Config class
+
+To build using the default config
+
+	haxe build.hxml
+
+
+To build using the debug partial config
+
+	haxe build-debug.hxml

--- a/example/properties/build-debug.hxml
+++ b/example/properties/build-debug.hxml
@@ -1,0 +1,33 @@
+-main Main
+-swf main.swf
+-swf-version 10
+-swf-header 1024:769:60:FFFFFF
+-lib mpartial
+-cp src
+-debug
+--next
+
+-main Main
+-js main.js
+-cp src
+-lib mpartial
+-debug
+-D web
+
+--next
+
+-main Main
+-neko build/main.n
+-lib mpartial
+-cp src
+-debug
+-cmd neko build/main.n
+
+--next
+
+-main Main
+-cpp build/main_cpp
+-lib mpartial
+-cp src
+-debug
+-cmd build/main_cpp/Main-debug

--- a/example/properties/build.hxml
+++ b/example/properties/build.hxml
@@ -1,0 +1,29 @@
+-main Main
+-swf main.swf
+-swf-version 10
+-swf-header 1024:769:60:FFFFFF
+-lib mpartial
+-cp src
+--next
+
+-main Main
+-js main.js
+-cp src
+-lib mpartial
+-D web
+
+--next
+
+-main Main
+-neko build/main.n
+-lib mpartial
+-cp src
+-cmd neko build/main.n
+
+--next
+
+-main Main
+-cpp build/main_cpp
+-lib mpartial
+-cp src
+-cmd build/main_cpp/Main

--- a/example/properties/src/Main.hx
+++ b/example/properties/src/Main.hx
@@ -20,17 +20,25 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+import example.Config;
 
 class Main
 {
 	static public function main()
 	{
-		var display = new example.SubDisplay();
-		display.x = 10;
-		display.y = 10;
-		display.width = 200;
-		display.height = 150;
+		// statics
+		trace("s1 " + Config.s1);
+		trace("s2 " + Config.s2);
+		trace("s3 " + untyped Config.s3);
+		trace("s4 " + untyped Config.s4);
 
-		trace(display.debug);
+		//instance
+		var config = new Config();
+		trace("a " + config.a);
+		trace("b " + config.b);
+		trace("c " + config.c);
+		trace("d " + config.d);
+		trace("e " + untyped  config.e);
+		trace("f " + untyped  config.f);
 	}
 }

--- a/example/properties/src/example/Config.hx
+++ b/example/properties/src/example/Config.hx
@@ -20,17 +20,48 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+package example;
 
-class Main
+class Config implements mpartial.Partial
 {
-	static public function main()
-	{
-		var display = new example.SubDisplay();
-		display.x = 10;
-		display.y = 10;
-		display.width = 200;
-		display.height = 150;
+	//-------------------------------------------------------------------------- public static accessors
 
-		trace(display.debug);
+	static public var s1:Bool = false;
+	inline public static var s2:Bool = false; 
+
+	//-------------------------------------------------------------------------- private static accessors
+
+	static var s3:Bool = false;
+	inline static var s4:Bool = false;
+
+	//-------------------------------------------------------------------------- public accessors
+	public var a:Bool;
+	public var b:Bool = false;
+
+	public var c(default, null):Bool;
+	
+	public var d(get_d, set_d):Bool;
+
+	function get_d():Bool{
+		return false;
 	}
+	function set_d(value:Bool):Bool
+	{
+		d = value;
+		return d;
+	}
+
+	//-------------------------------------------------------------------------- private accessors
+
+	var e:Bool = true;
+
+	@PartialFinal
+	var f:Bool = true;
+	
+
+	public function new()
+	{
+		
+	}
+
 }

--- a/example/properties/src/example/Config_debug.hx
+++ b/example/properties/src/example/Config_debug.hx
@@ -1,0 +1,107 @@
+/*
+Copyright (c) 2012 Massive Interactive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of 
+this software and associated documentation files (the "Software"), to deal in 
+the Software without restriction, including without limitation the rights to 
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
+of the Software, and to permit persons to whom the Software is furnished to do 
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.
+*/
+
+package example;
+
+class Config_debug
+{
+	//--------------------------------------------------------------------------  static accessors
+
+	//change to inline, override value
+
+	@PartialReplace
+	inline static public var s1:Bool = true;
+
+	//remove inline, override value
+
+	@PartialReplace
+	static public var s2:Bool = true;
+
+	@PartialReplace
+	static var s3:Bool = true;
+
+	@PartialReplace
+	inline static var s4:Bool = true;
+
+	//-------------------------------------------------------------------------- public accessors
+	
+	// set default value
+
+	@PartialReplace
+	public var a:Bool = true;
+
+	// convert to getter/setter and set default value
+
+	@PartialReplace
+	public var b(get_b, set_b):Bool = true;
+
+	function get_b():Bool{
+		return b;
+	}
+	function set_b(value:Bool):Bool
+	{
+		b = value;
+		return b;
+	}
+
+
+	// modify getter/setter accessors
+
+	@PartialReplace
+	public var c(get_c, set_c):Bool;
+
+	function get_c():Bool
+	{
+		return true;
+	}
+
+	function set_c(value:Bool):Bool
+	{
+		return c;
+	}
+
+	// modify getter method
+
+	@PartialReplace
+	public var d(get_d2, set_d):Bool;
+
+	function get_d2():Bool
+	{
+		return true;
+	}
+
+	//-------------------------------------------------------------------------- private accessors
+
+	//convert to public, inherit existing default value;
+
+	@PartialReplace
+	public var e:Bool;
+
+
+	//cannot override property marked with @PartialFinal
+
+	// @PartialReplace
+	// var f:Bool = true;
+
+
+}
+

--- a/src/mpartial/parser/MethodHelper.hx
+++ b/src/mpartial/parser/MethodHelper.hx
@@ -32,7 +32,7 @@ import haxe.PosInfos;
 Data type representing a method in a class.
 Includes utilities for checking method level partials metadata 
 */
-class Method
+class MethodHelper
 {
 	
 	public inline static var META_APPEND:String = "PartialAppend";
@@ -71,7 +71,7 @@ class Method
 
 		if (isInlined && !isStrictInlined()) 
 		{
-			Context.warning("@" + Method.META_INLINED + " does not support methods with parameters or arguments. " + qualifiedClassName + "." + field.name, f.expr.pos);
+			Context.warning("@" + MethodHelper.META_INLINED + " does not support methods with parameters or arguments. " + qualifiedClassName + "." + field.name, f.expr.pos);
 			
 			field.access.remove(AInline);
 			field.access.push(AInline);

--- a/src/mpartial/parser/PartialClassParser.hx
+++ b/src/mpartial/parser/PartialClassParser.hx
@@ -35,7 +35,7 @@ import msys.Directory;
 import mpartial.util.ClassUtil;
 
 /**
-Parsers base Partial class and force compiles additional partial implementations
+Parses base Partial class and forces compilation of additional partial implementations
 */
 class PartialClassParser extends BaseParser
 {
@@ -43,7 +43,8 @@ class PartialClassParser extends BaseParser
 
 	var isPartialClass:Bool;
 
-	public var methods:Hash<Method>;
+	public var methods:Hash<MethodHelper>;
+	public var properties:Hash<PropertyHelper>;
 
 	var exprStack(default, null):Array<Expr>;
 
@@ -77,6 +78,7 @@ class PartialClassParser extends BaseParser
 		}
 
 		methods = new Hash();
+		properties = new Hash();
 
 		if (fields == null) fields = Context.getBuildFields();
 		this.fields = fields;
@@ -119,10 +121,19 @@ class PartialClassParser extends BaseParser
 	    	{
 	    		case FFun(f): 
 	    		{
-	    			var method = new Method(field, f, qualifiedClassName);
+	    			var method = new MethodHelper(field, f, qualifiedClassName);
 					methods.set(field.name, method);
 	    		}
-	    		default: null;
+	    		case FVar(t,e): 
+	    		{
+	    			var property = new PropertyHelper(field, qualifiedClassName);
+					properties.set(field.name, property);
+	    		}
+	    		case FProp(get,set,t, e): 
+	    		{
+	    			var property = new PropertyHelper(field, qualifiedClassName);
+					properties.set(field.name, property);
+	    		}
 	    	}
         }
 	}
@@ -322,7 +333,7 @@ class PartialClassParser extends BaseParser
 		e = parseExpr(e);
 		params = parseExprs(params);
 
-		var method:Method = null;
+		var method:MethodHelper = null;
 
 		switch(e.expr)
 		{

--- a/src/mpartial/parser/PropertyHelper.hx
+++ b/src/mpartial/parser/PropertyHelper.hx
@@ -1,0 +1,149 @@
+/*
+Copyright (c) 2012 Massive Interactive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of 
+this software and associated documentation files (the "Software"), to deal in 
+the Software without restriction, including without limitation the rights to 
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
+of the Software, and to permit persons to whom the Software is furnished to do 
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.
+*/
+
+package mpartial.parser;
+
+#if macro
+import haxe.macro.Expr;
+import haxe.macro.Context;
+import haxe.macro.Compiler;
+import haxe.PosInfos;
+
+/**
+Data type representing a FVar field in a class.
+Includes utilities for checking property level partials metadata 
+*/
+class PropertyHelper
+{
+	
+	public inline static var META_REPLACE:String = "PartialReplace";
+	public inline static var META_FINAL:String = "PartialFinal";
+
+	public var field:Field;
+	public var type(default, null):Null<ComplexType>;
+	public var expr(default, set_expr):Null<Expr>;
+	public var isFProp(default, null):Bool;
+
+	public var isFinal(default, null):Bool;
+	public var isReplace(default, null):Bool;
+
+	public var hasPartialImplementationMetadata(default, null):Bool;
+
+	public var qualifiedClassName(default, null):String;
+
+	var getMethod:String;
+	var setMethod:String;
+
+	public function new(field:Field, qualifiedClassName:String)
+	{
+		this.field = field;
+		this.qualifiedClassName = qualifiedClassName;
+
+		isFinal = false;
+		isReplace = false;
+
+		hasPartialImplementationMetadata = false;
+
+		switch(field.kind)
+		{
+			case FVar(t, e):
+			{
+				isFProp = false;
+				type = t;
+				Reflect.setField(this, "expr", e);
+			}
+			case FProp(get,set,t,e):
+			{
+				isFProp = true;
+				type = t;
+				Reflect.setField(this, "expr", e);
+				getMethod = get;
+				setMethod = set;
+			}
+			default:
+			{
+				throw "Invalid field kind: " + field.kind;
+			}
+		}
+
+		parseMetadata(field.meta);
+	}
+
+	function set_expr(expr:Null<Expr>):Null<Expr>
+	{
+		if(expr != this.expr)
+		{
+			this.expr = expr;
+
+			if(isFProp)
+			{
+				field.kind = FProp(getMethod, setMethod, type, expr);
+			}
+			else
+			{
+				field.kind = FVar(type, expr);
+			}
+		}
+
+		return this.expr;
+	}
+
+	public function hasAccess(access:Access):Bool
+	{
+		for(a in field.access)
+		{
+			if(a == access) return true;
+		}
+		return false;
+	}
+
+	public function getPos():Position
+	{
+		if(expr != null)
+		{
+			return expr.pos;
+		}
+		return Context.currentPos();
+	}
+
+	function parseMetadata(meta:Metadata)
+	{
+		for (item in meta)
+		{
+			switch(item.name.toLowerCase())
+			{
+				case META_FINAL.toLowerCase(): isFinal = true;
+				case META_REPLACE.toLowerCase(): isReplace = true;
+			}
+		}
+
+		hasPartialImplementationMetadata = isReplace;
+	}
+
+	function invalidMetadata(meta:String)
+	{
+		Context.error("Unexpected metadata argument for @" + meta + " at " + field.name, Context.currentPos());
+	}
+
+}	
+
+#end


### PR DESCRIPTION
added example for property partials - example/properties
updated read me for property partials

---

Property fields support a subset of partial metadata options:
### Replace

Overrides the base class property definition.

```
@PartialReplace
public var property:String = "foo";
```

Unlike methods, there are some restrictions on overriding a property to avoid breaking compatibility with other classes using the public API. This prevents properties being changed from public to private, static to instance, etc
- Compiler error if base propery is marked as final
- Compiler error if property has no partial metadata (invalid override)
- Compiler error if property overriden multiple times in the one partial file
- Compiler error if property types do not match
- Compiler error if converting getter/setter to a simple var
- Compiler error if adding/removing static accessor
- Compiler error if changing/removing existing public access
- Compiler warning if adding/removing inline accessor
- Compiler warning if adding public accessor
### Final

Prevents partial classes from modifiying base instance.

```
@PartialFinal
public var property:String = "bar";
```
