### PR TITLE
updated build metadata names from @Partial* to @:partial*

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ Individual platforms provide additional/bespoke implementations
 
 	class Foo_js
 	{
-		@PartialAppend
+		@:partialAppend
 		public function new()
 		{
 			bar = 1;
 		}
 
-		@PartialReplace
+		@:partialReplace
 		function doSomething(value:Int)
 		{
 			bar += value;
@@ -143,7 +143,7 @@ To modify an existing method requires one of the metadata options below:
 
 Appends expressions to the end of the base class
 
-	@PartialAppend
+	@:partialAppend
 	function test()
 	{
 		//appends to end of method expressions
@@ -153,7 +153,7 @@ Appends expressions to the end of the base class
 
 Overrides the entire contents of the method rather than just appending to the end of it 
 
-	@PartialReplace
+	@:partialReplace
 	function test()
 	{
 		//will override expressions all existing expressions
@@ -165,7 +165,7 @@ Overrides the entire contents of the method rather than just appending to the en
 
 Prevents partial classes from modifiying base implementation.
 
-	@PartialFinal
+	@:partialFinal
 	function test()
 	{
 		//cannot be modified/extended by other implementations
@@ -173,7 +173,7 @@ Prevents partial classes from modifiying base implementation.
 
 Modifying this method in an implementation class will cause a compilation error:
 
-	example.Test_Foo:14 Cannot override @PartialFinal in example.Test.run
+	example.Test_Foo:14 Cannot override @:partialFinal in example.Test.run
 			
 
 
@@ -186,7 +186,7 @@ This can be used to append expressions relative to the start or end of a method.
 
 Appending at start of a method (index 0)
 
-	@PartialInsertAt(0)
+	@:partialInsertAt(0)
 	function test()
 	{
 		//will insert expressions at index 0 (before any existing expressions)
@@ -195,7 +195,7 @@ Appending at start of a method (index 0)
 Appending at a specific index (index 1)
 
 
-	@PartialInsertAt(1)
+	@:partialInsertAt(1)
 	function test()
 	{
 		//will insert expressions immediately after the first expression
@@ -203,7 +203,7 @@ Appending at a specific index (index 1)
 
 Appending relative to the end of the method expressions (index -1)
 
-	@PartialInsertAt(-1)
+	@:partialInsertAt(-1)
 	function test()
 	{
 		//will insert expressions immediately before the last expression.
@@ -217,7 +217,7 @@ Appending relative to the end of the method expressions (index -1)
 Similar to Haxe's inline accessor, but litterally injects expressions at the location where the method is called.
  Unlike Haxe's `inline` accessor, this will only inline references within the Partial class.
 
-	@PartialInline
+	@:partialInline
 	function test()
 	{
 		//will insert expressions directly into calling function
@@ -225,7 +225,7 @@ Similar to Haxe's inline accessor, but litterally injects expressions at the loc
 
 **Note:** This feature in not supported by methods with parameters. For example:
 
-	@PartialInline
+	@:partialInline
 	function test(value:Bool)
 	{
 		//cannot insert into calling function because of value parameter
@@ -235,7 +235,7 @@ Similar to Haxe's inline accessor, but litterally injects expressions at the loc
 
 Using this metadata tag on a predefined method in an implementation class will cause a compilation warning, and attempt to convert the method to a traditional haxe `inline` function.
 
-	WARNING: example.Test_Foo:14 Cannot define @PartialInline in a partial implementation of example.Test
+	WARNING: example.Test_Foo:14 Cannot define @:partialInline in a partial implementation of example.Test
 	WARNING: example.Test_Foo:14 Converting method foo to standard haxe inline accesor.
 
 
@@ -248,7 +248,7 @@ Property fields support a subset of partial metadata options:
 
 Overrides the base class property definition.
 
-	@PartialReplace
+	@:partialReplace
 	public var property:String = "foo";
 
 Unlike methods, there are some restrictions on overriding a property to avoid breaking compatibility with other classes using the public API. This prevents properties being changed from public to private, static to instance, etc
@@ -267,7 +267,7 @@ Unlike methods, there are some restrictions on overriding a property to avoid br
 
 Prevents partial classes from modifiying base instance.
 
-	@PartialFinal
+	@:partialFinal
 	public var property:String = "bar";
 
 

--- a/example/basic/src/example/Display_debug.hx
+++ b/example/basic/src/example/Display_debug.hx
@@ -25,16 +25,16 @@ package example;
 
 class Display_debug
 {
-	@PartialReplace
+	@:partialReplace
 	public var debug:Bool = true;
 
-	@PartialAppend
+	@:partialAppend
 	public function new()
 	{
 		trace("debug new");
 	}
 
-	@PartialAppend
+	@:partialAppend
 	function redraw()
 	{
 		trace("debug redraw");

--- a/example/basic/src/example/Display_flash.hx
+++ b/example/basic/src/example/Display_flash.hx
@@ -28,14 +28,14 @@ class Display_flash
 {
 	var sprite:Sprite;
 
-	@PartialAppend
+	@:partialAppend
 	public function new()
 	{
 		sprite = new Sprite();
 		flash.Lib.current.addChild(sprite);
 	}
 
-	@PartialAppend
+	@:partialAppend
 	function redraw()
 	{
 		sprite.x = x;

--- a/example/basic/src/example/Display_js.hx
+++ b/example/basic/src/example/Display_js.hx
@@ -29,7 +29,7 @@ class Display_js
 {
 	var element:HtmlDom;
 
-	@PartialAppend
+	@:partialAppend
 	public function new()
 	{
 		element = Lib.document.createElement("div");
@@ -38,7 +38,7 @@ class Display_js
 		Lib.document.body.appendChild(element);
 	}
 
-	@PartialAppend
+	@:partialAppend
 	function redraw()
 	{
 		element.style.marginTop = x + "px";

--- a/example/basic/src/example/Display_neko.hx
+++ b/example/basic/src/example/Display_neko.hx
@@ -24,13 +24,13 @@ package example;
 
 class Display_neko
 {
-	@PartialAppend
+	@:partialAppend
 	public function new()
 	{
 		neko.Lib.println("    NEKO: create new Display");
 	}	
 
-	@PartialAppend
+	@:partialAppend
 	function redraw()
 	{
 		var str = "{x:" + x + ", y:" + y + ", width:" + width + ", height:" + height + "}";

--- a/example/metadata/src/example/Test.hx
+++ b/example/metadata/src/example/Test.hx
@@ -87,13 +87,13 @@ class Test implements mpartial.Partial
 		print(property, 1);
 	}
 
-	@PartialInline
+	@:partialInline
 	function inlineMethod()
 	{
 		print(property, 1);
 	}
 
-	@PartialFinal
+	@:partialFinal
 	function finalMethod()
 	{
 		print(property, 1);

--- a/example/metadata/src/example/Test_bar.hx
+++ b/example/metadata/src/example/Test_bar.hx
@@ -26,25 +26,25 @@ class Test_bar
 {
 	var bar:String;
 
-	@PartialAppend
+	@:partialAppend
 	function new()
 	{
 		bar = "bar";
 	}
 
-	@PartialAppend
+	@:partialAppend
 	function appendMethod()
 	{
 		print(bar, 3);
 	}
 
-	@PartialReplace
+	@:partialReplace
 	function overrideMethod()
 	{
     	print(bar,3);
 	}
 
-	@PartialAppend
+	@:partialAppend
 	function addMethod()
 	{
 		print(bar, 3);

--- a/example/metadata/src/example/Test_foo.hx
+++ b/example/metadata/src/example/Test_foo.hx
@@ -26,50 +26,50 @@ class Test_foo
 {
 	var foo:String;	
 	
-	@PartialAppend
+	@:partialAppend
 	function new()
 	{
 		foo = "foo";
 	}	
 
-	@PartialAppend
+	@:partialAppend
 	function appendMethod()
 	{
 		print(foo,2);
 	}
 
-	@PartialInsertAt(0)
+	@:partialInsertAt(0)
 	function appendMethodBefore()
 	{
 		print(foo + " 0",2);
 	}
 
-	@PartialInsertAt(1)
+	@:partialInsertAt(1)
 	function appendMethodRelativeToStart()
 	{
 		print(foo + " 1",2);
 	}
 
-	@PartialInsertAt(-1)
+	@:partialInsertAt(-1)
 	function appendMethodRelativeToEnd()
 	{
 		print(foo + " -1",2);
 	}	
 
-	@PartialReplace
+	@:partialReplace
 	function overrideMethod()
 	{
 		print(foo,2);
 	}	
 	
-	@PartialAppend
+	@:partialAppend
 	function inlineMethod()
 	{
 		print(foo,2);
 	}	
 
 	/**
-	would cause compiler error because parent method is marked with @PartialFinal
+	would cause compiler error because parent method is marked with @:partialFinal
 	*/ 
 	// function finalMethod()
 	// {

--- a/example/properties/src/example/Config.hx
+++ b/example/properties/src/example/Config.hx
@@ -55,7 +55,7 @@ class Config implements mpartial.Partial
 
 	var e:Bool = true;
 
-	@PartialFinal
+	@:partialFinal
 	var f:Bool = true;
 	
 

--- a/example/properties/src/example/Config_debug.hx
+++ b/example/properties/src/example/Config_debug.hx
@@ -28,30 +28,30 @@ class Config_debug
 
 	//change to inline, override value
 
-	@PartialReplace
+	@:partialReplace
 	inline static public var s1:Bool = true;
 
 	//remove inline, override value
 
-	@PartialReplace
+	@:partialReplace
 	static public var s2:Bool = true;
 
-	@PartialReplace
+	@:partialReplace
 	static var s3:Bool = true;
 
-	@PartialReplace
+	@:partialReplace
 	inline static var s4:Bool = true;
 
 	//-------------------------------------------------------------------------- public accessors
 	
 	// set default value
 
-	@PartialReplace
+	@:partialReplace
 	public var a:Bool = true;
 
 	// convert to getter/setter and set default value
 
-	@PartialReplace
+	@:partialReplace
 	public var b(get_b, set_b):Bool = true;
 
 	function get_b():Bool{
@@ -66,7 +66,7 @@ class Config_debug
 
 	// modify getter/setter accessors
 
-	@PartialReplace
+	@:partialReplace
 	public var c(get_c, set_c):Bool;
 
 	function get_c():Bool
@@ -81,7 +81,7 @@ class Config_debug
 
 	// modify getter method
 
-	@PartialReplace
+	@:partialReplace
 	public var d(get_d2, set_d):Bool;
 
 	function get_d2():Bool
@@ -93,13 +93,13 @@ class Config_debug
 
 	//convert to public, inherit existing default value;
 
-	@PartialReplace
+	@:partialReplace
 	public var e:Bool;
 
 
-	//cannot override property marked with @PartialFinal
+	//cannot override property marked with @:partialFinal
 
-	// @PartialReplace
+	// @:partialReplace
 	// var f:Bool = true;
 
 

--- a/src/mpartial/PartialsMacro.hx
+++ b/src/mpartial/PartialsMacro.hx
@@ -162,12 +162,12 @@ class PartialsMacro
 	{
 		init();
 
-		trace("@:build");
+		trace("PartialsMacro.build");
 
 		classParser = new PartialClassParser(fields);
 		classParser.build(partialTargets);
 
-		trace("@:build complete", true);
+		trace("PartialsMacro.build complete", true);
 
 		return classParser.fields;
 	}
@@ -177,13 +177,13 @@ class PartialsMacro
 	*/
 	@:macro public static function appendToPartial(expr:Expr):Array<Field>
 	{
-		trace("@:buildPartial");
+		trace("PartialsMacro.buildPartial");
 
 		var implementationParser = new PartialImplementationParser();
 
 		implementationParser.appendTo(classParser);
 
-		trace("@:buildPartial complete", true);
+		trace("PartialsMacro.buildPartial complete", true);
 
 		Compiler.exclude(implementationParser.qualifiedClassName, false);
 		return [];

--- a/src/mpartial/parser/MethodHelper.hx
+++ b/src/mpartial/parser/MethodHelper.hx
@@ -35,11 +35,11 @@ Includes utilities for checking method level partials metadata
 class MethodHelper
 {
 	
-	public inline static var META_APPEND:String = "PartialAppend";
-	public inline static var META_REPLACE:String = "PartialReplace";
-	public inline static var META_FINAL:String = "PartialFinal";
-	public inline static var META_INLINED:String = "PartialInline";
-	public inline static var META_INSERT_AT:String = "PartialInsertAt";
+	public inline static var META_APPEND:String = ":partialAppend";
+	public inline static var META_REPLACE:String = ":partialReplace";
+	public inline static var META_FINAL:String = ":partialFinal";
+	public inline static var META_INLINED:String = ":partialInline";
+	public inline static var META_INSERT_AT:String = ":partialInsertAt";
 
 	public var field:Field;
 	public var f:Function;

--- a/src/mpartial/parser/PropertyHelper.hx
+++ b/src/mpartial/parser/PropertyHelper.hx
@@ -35,8 +35,8 @@ Includes utilities for checking property level partials metadata
 class PropertyHelper
 {
 	
-	public inline static var META_REPLACE:String = "PartialReplace";
-	public inline static var META_FINAL:String = "PartialFinal";
+	public inline static var META_REPLACE:String = ":partialReplace";
+	public inline static var META_FINAL:String = ":partialFinal";
 
 	public var field:Field;
 	public var type(default, null):Null<ComplexType>;


### PR DESCRIPTION
Updated to adhere to best practise for Haxe build macros
- colon before label
- lower camel case
