### PR TITLE
Remove any duplicate target flags

### DIFF
--- a/src/mpartial/PartialsMacro.hx
+++ b/src/mpartial/PartialsMacro.hx
@@ -166,6 +166,8 @@ class PartialsMacro
 		{
 			targets.push("debug");
 		}
+		
+		targets = removeDuplicates(targets);
 
 		trace("default targets", defaultTargets);
 		trace("custom targets", customTargets);
@@ -216,6 +218,15 @@ class PartialsMacro
 		
 		return targets;
 		
+	}
+	
+	static function removeDuplicates(values:Array<String>):Array<String>
+	{
+		var uniqueValues:Array<String> = [];
+		for (value in values)
+			if (!Lambda.has(uniqueValues, value))
+				uniqueValues.push(value);
+		return uniqueValues;
 	}
 
 	//-------------------------------------------------------------------------- Build macros


### PR DESCRIPTION
In the case where duplicate flags are passed to mpartial, the partial macro will generate twice for that flag causing potential compilation errors.

This fix ensures duplicate flags are removed while maintaining the correct priority order.
